### PR TITLE
Bump version for security fix in dimeo-portal project

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,4 +7,4 @@ djangorestframework>=3.10.3
 idna==2.8
 PyJWT==1.7.1
 python-dateutil==2.8.1
-urllib3==1.25.7
+urllib3==1.25.10


### PR DESCRIPTION
I've bumped the version of `urllib3` as the security checks in the `dimeo-portal` project are flagging `urllib3==1.25.7` as a potential security issue.

It's just a patch number so shouldn't break anything.